### PR TITLE
Changed IEventStore.Find method overload type from System.Func<T, bool> to System.Linq.Expressions.Expression<System.Func<T, bool>>

### DIFF
--- a/src/MementoFX.Tests/InMemoryEventStore.cs
+++ b/src/MementoFX.Tests/InMemoryEventStore.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using MementoFX.Domain;
+using MementoFX.Messaging;
+using MementoFX.Persistence;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using MementoFX.Domain;
-using MementoFX.Persistence;
-using MementoFX.Messaging;
-using EventCondition = System.Linq.Expressions.Expression<System.Func<MementoFX.Persistence.EventMapping, bool>>;
+using System.Linq.Expressions;
 
 namespace MementoFX.Persistence.InMemory
 {
@@ -30,9 +30,9 @@ namespace MementoFX.Persistence.InMemory
         /// <typeparam name="T">The type of the event</typeparam>
         /// <param name="filter">The requirement</param>
         /// <returns>The events which satisfy the given requirement</returns>
-        public override IEnumerable<T> Find<T>(Func<T, bool> filter)
+        public override IEnumerable<T> Find<T>(Expression<Func<T, bool>> filter)
         {
-            return Events.OfType<T>().Where(filter);
+            return Events.OfType<T>().Where(filter.Compile());
         }
 
         /// <summary>

--- a/src/MementoFX/Persistence/EventStore.cs
+++ b/src/MementoFX/Persistence/EventStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,7 +37,7 @@ namespace MementoFX.Persistence
         /// <typeparam name="T">The type of the events to retrieve</typeparam>
         /// <param name="filter">The condition events must satisfy in order to be retrieved.</param>
         /// <returns>The events which satisfy the specified condition</returns>
-        public abstract IEnumerable<T> Find<T>(Func<T, bool> filter) where T : DomainEvent;
+        public abstract IEnumerable<T> Find<T>(Expression<Func<T, bool>> filter) where T : DomainEvent;
 
         /// <summary>
         /// Retrieves the desired events from the store

--- a/src/MementoFX/Persistence/IEventStore.cs
+++ b/src/MementoFX/Persistence/IEventStore.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -18,7 +19,7 @@ namespace MementoFX.Persistence
         /// <typeparam name="T">The type of the events to retrieve</typeparam>
         /// <param name="filter">The condition events must satisfy in order to be retrieved.</param>
         /// <returns>The events which satisfy the specified condition</returns>
-        IEnumerable<T> Find<T>(Func<T,bool> filter) where T : DomainEvent;
+        IEnumerable<T> Find<T>(Expression<Func<T,bool>> filter) where T : DomainEvent;
 
         /// <summary>
         /// Retrieves the desired events from the store


### PR DESCRIPTION
The goal of this PR is to supports new IEventStore implementations based on other persistence solutions that cannot support the Find<T> with overload of type `System.Func<T, bool>` as filter, because of their engine's query translations that use `System.Linq.Expressions.Expression<Func<T, bool>>` as filter type, as described in [Issue #6](https://github.com/MementoFX/MementoFX/issues/6).